### PR TITLE
fix generated filelist

### DIFF
--- a/src/experiments/compute_distance_matrices/gen_filelist_fixedview.py
+++ b/src/experiments/compute_distance_matrices/gen_filelist_fixedview.py
@@ -4,7 +4,7 @@ sys.path.append(os.path.dirname(os.path.dirname(BASE_DIR)))
 from global_variables import *
 
 img_root_dir = g_fixedview_image_folder
-modelIds = [x.rstrip().split(' ')[0] for x in open(g_shape_list_file,'r')]
+modelIds = [x.rstrip().split(' ')[1] for x in open(g_shape_list_file,'r')]
 elevatio_degs = g_fixedview_elevation_degs
 azimuth_degs = g_fixedview_azimuth_degs
 


### PR DESCRIPTION
The lines in shape_list are like 

> 02691156 10155655850468db78d106ce0a280f87
> 02691156 1021a0914a7207aff927ed529ad90a11
> ..

, so modelId should be x.rstrip().split(' ')[1], not [0].